### PR TITLE
feat: add custom manager for Go tools installation script in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,17 @@
       "matchManagers": ["gomod"],
       "enabled": false
     }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^scripts/install-go-tools.sh$"
+      ],
+      "matchStrings": [
+        "go install (?<depName>[^@]+?)@(?<currentValue>.+)\n"
+      ],
+      "datasourceTemplate": "go"
+    }
   ]
 }


### PR DESCRIPTION

# What
- [x] feat: add custom manager for Go tools installation script in renovate config
