### PR TITLE
fix: update regex to exclude xk6 in install-go-tools.sh match

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
         "^scripts/install-go-tools.sh$"
       ],
       "matchStrings": [
-        "go install (?<depName>[^@]+?)@(?<currentValue>.+)\n"
+        "go install ^(?!.*xk6)(?<depName>[^@]+?)@(?<currentValue>.+)\n"
       ],
       "datasourceTemplate": "go"
     }


### PR DESCRIPTION
<!-- This is just a template, so you can change it to whatever format you like. (What, Why, Related issues, if possible)-->

# What
<!-- Changed contents, if possible something easy to understand that can be evidence of the change. (e.g. screen changes, implementation process dumps, etc.)-->
- [x]  exclude `go.k6.io/xk6/cmd/xk6` 
# Why
<!-- Write the purpose of the change and related stories (e.g. the screen is hard to see, the user wants something like this) -->

renovate cannot access  `https://go.k6.io/xk6/cmd/xk6`
