### PR TITLE
fix: remove github.com/grafana/xk6-output-prometheus-remote

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-ARG K6_VERSION
 ARG XK6_VERSION
 ARG K6_PROMTHEUS_VERSION
 
 FROM golang:1.24.5 AS builder
-ARG K6_VERSION=v0.56.0
 ARG XK6_VERSION=v0.13.4
-ARG K6_PROMETHEUS_VERSION=v0.3.1
 
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 RUN go install -trimpath go.k6.io/xk6/cmd/xk6@${XK6_VERSION}
 RUN xk6 build \
-    --with github.com/grafana/xk6-output-prometheus-remote@${K6_PROMETHEUS_VERSION} \
     --with github.com/grafana/xk6-dashboard@latest \
     --with github.com/bbsakura/xk6-diameter@latest=.
 


### PR DESCRIPTION
<!-- This is just a template, so you can change it to whatever format you like. (What, Why, Related issues, if possible)-->

# What
<!-- Changed contents, if possible something easy to understand that can be evidence of the change. (e.g. screen changes, implementation process dumps, etc.)-->
- [x] remove [xk6-output-prometheus-remote](https://github.com/grafana/xk6-output-prometheus-remote/blob/main/README.md)
`
The xk6-output-prometheus-remote extension https://github.com/grafana/k6/pull/4519 to the [main k6 repository](https://github.com/grafana/k6).`