### PR TITLE
fix: update golangci-lint to v8 and fix golangci-lint install script

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           go-version: ^1.21
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
       - name: go mod tidy and install

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,54 +1,68 @@
-run:
-  timeout: 15m
-
-output:
-  sort-results: true
-
+version: "2"
 linters:
   enable:
     - depguard
     - gocritic
-    - gofumpt
-    - goimports
     - misspell
     - predeclared
     - revive
     - unconvert
-    - unused
-
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/stretchr/testify/assert
+              desc: Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert
+            - pkg: io/ioutil
+              desc: Use corresponding 'os' or 'io' functions instead.
+    errcheck:
+      exclude-functions:
+        - example/**
+    revive:
+      rules:
+        - name: unused-parameter
+          severity: warning
+          disabled: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+        path: _test.go
+      - linters:
+          - staticcheck
+        path: tools.go
+    paths:
+      - tools.go
+      - cmd/hss-client/main.go
+      - cmd/hss-server/main.go
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-same-issues: 0
-  exclude-rules:
-    - path: _test.go
-      linters:
-        - errcheck
-    - path: tools.go
-      linters:
-        - stylecheck
-  exclude-files:
-    - tools.go
-    - cmd/hss-client/main.go
-    - cmd/hss-server/main.go
-
-linters-settings:
-  depguard:
-    rules:
-      main:
-        deny:
-        - pkg: "github.com/stretchr/testify/assert"
-          desc: "Use github.com/stretchr/testify/require instead of github.com/stretchr/testify/assert"
-        - pkg: "io/ioutil"
-          desc: "Use corresponding 'os' or 'io' functions instead."
-  errcheck:
-    exclude-functions:
-      - example/**
-  goimports:
-    local-prefixes: github.com/bbsakura
-  gofumpt:
-    extra-rules: true
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
-        disabled: true
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/bbsakura
+  exclusions:
+    generated: lax
+    paths:
+      - tools.go
+      - cmd/hss-client/main.go
+      - cmd/hss-server/main.go
+      - third_party$
+      - builtin$
+      - examples$

--- a/scripts/install-go-tools.sh
+++ b/scripts/install-go-tools.sh
@@ -3,7 +3,7 @@
 go install github.com/dmarkham/enumer@v1.5.11
 go install github.com/elisescu/tty-share@v0.6.2
 go install github.com/erkanzileli/co-author@v0.0.7
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v2.4.0
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
 go install go.k6.io/xk6/cmd/xk6@v0.13.4
 go install golang.org/x/tools/cmd/goimports@v0.32.0
 go install golang.org/x/tools/cmd/stringer@v0.32.0


### PR DESCRIPTION
This pull request updates the configuration and usage of `golangci-lint` to the latest major version and restructures the linting settings for improved maintainability and compatibility. The most significant changes are the upgrade to `golangci-lint` v8, changes to the configuration syntax in `.golangci.yml`, and an updated installation command for the linter.

**golangci-lint upgrade and configuration changes:**

* Upgraded the GitHub Action for `golangci-lint` from v6 to v8 in `.github/workflows/lint_and_test.yaml`, ensuring compatibility with the latest linter features and improvements.
* Updated the installation path for `golangci-lint` in `scripts/install-go-tools.sh` to use the new v2 module path, aligning with upstream changes.

**Linting configuration restructuring:**

* Refactored `.golangci.yml` to use the new version 2 syntax, reorganized linter settings, exclusions, and formatter configurations for better clarity and maintainability. This includes moving `gofumpt` and `goimports` under `formatters`, updating exclusion rules, and streamlining linter settings.